### PR TITLE
voice commands, query improvements, import voices functionality

### DIFF
--- a/src/helpers/config.py
+++ b/src/helpers/config.py
@@ -28,6 +28,12 @@ class TCDNDConfig(configparser.ConfigParser):
         if not self.get(section="BOT", option="join_command", fallback=None):
             needs_init = True
             self.set(section="BOT", option="join_command", value="join")
+        if not self.get(section="BOT", option="voices_command", fallback=None):
+            needs_init = True
+            self.set(section="BOT", option="voices_command", value="voices")
+        if not self.get(section="BOT", option="voice_command", fallback=None):
+            needs_init = True
+            self.set(section="BOT", option="voice_command", value="voice")
 
         if not self.has_section("SERVER"):
             needs_init = True

--- a/src/tts/local_tts.py
+++ b/src/tts/local_tts.py
@@ -10,7 +10,7 @@ from helpers.utils import run_coroutine_sync
 from helpers.constants import SOURCE_LOCAL
 from custom_logger.logger import logger
 
-from data.voices import _upsert_voice, fetch_voices
+from data.voices import _upsert_voice, fetch_voices, get_all_voice_ids
 from data import Voice
 
 
@@ -18,7 +18,7 @@ from data import Voice
 
 
 class LocalTTS(TTS): 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, full_instance: bool = True):
         super().__init__(config=None)
         
         self.sample_rate = 22050 # PyTTS default
@@ -27,9 +27,12 @@ class LocalTTS(TTS):
 
         self.max_chunk_size = 1024*8*8*2*2 # 256kb
 
-        engine = pyttsx4.init() 
-        for v in engine.getProperty('voices'):
-            run_coroutine_sync(_upsert_voice(name=v.name, uid=v.id, source=SOURCE_LOCAL))
+        if full_instance:
+            engine = pyttsx4.init() 
+            db_voice_ids = run_coroutine_sync(get_all_voice_ids(source=SOURCE_LOCAL))
+            for v in engine.getProperty('voices'):
+                if v.id not in db_voice_ids:
+                    run_coroutine_sync(_upsert_voice(name=v.name, uid=v.id, source=SOURCE_LOCAL))
 
     @property
     def voices(self) -> dict:
@@ -38,6 +41,27 @@ class LocalTTS(TTS):
         for v in _voices:
             d.setdefault(f"{v.name}", v.uid)
         return d
+
+    def list_voices(self) -> list:
+        friendly_names = list()
+        engine = pyttsx4.init() 
+        for v in engine.getProperty('voices'):
+            n = v.name.split('-')[0].replace("Desktop", "").replace("Microsoft", "").strip()
+            friendly_names.append(n)
+        return friendly_names
+
+    def get_voice_id_by_friendly_name(self, name: str) -> str:
+        if not name:
+            return None
+        engine = pyttsx4.init() 
+        for v in engine.getProperty('voices'):
+            n = v.name.split('-')[0].replace("Desktop", "").replace("Microsoft", "").strip()
+            if n.lower() == name.lower().strip():
+                return v.id
+
+    def voice_list_message(self) -> str:
+        voices = self.list_voices()
+        return "Local Voices: " + ", ".join(voices)
 
     def audio_stream_generator(self, text="Hello World!", voice_id: str = None):
         engine = pyttsx4.init() # We are using the fork for x4 as it works with outputting to bytesIO

--- a/src/tts/tts.py
+++ b/src/tts/tts.py
@@ -39,3 +39,9 @@ class TTS():
     
     async def get_stream(self):
         yield (None, 0)
+
+    def list_voices(self) -> list:
+        return list()
+
+    def voice_list_message(self) -> str:
+        return "Available Voices: " + ", ".join(self.list_voices())

--- a/src/ui/tabs/settings.py
+++ b/src/ui/tabs/settings.py
@@ -80,6 +80,25 @@ class SettingsTab():
 
         twitchutils_twitch_on_connect_event.addListener(self._update_twitch_connect)
 
+        row += 1
+        column = 3
+        voice_cmd_label = ctk.CTkLabel(self.parent, text="Set Voice Command")
+        voice_cmd_label.grid(row=row, column=column, padx=(10,10), pady=(10,2))
+        column+=1
+        voices_cmd_label = ctk.CTkLabel(self.parent, text="List Voices Command")
+        voices_cmd_label.grid(row=row, column=column, padx=(10,10), pady=(10,2))
+        row += 1
+        column -= 1
+        self.voice_cmd_var = ctk.StringVar(value=self.config.get(section="BOT", option="voice_command", fallback=''))
+        voice_cmd_entry = ctk.CTkEntry(self.parent,  width=100, height=30, border_width=1, fg_color="white", placeholder_text="join", text_color="black", textvariable=self.voice_cmd_var)
+        voice_cmd_entry.grid(row=row, column=column, padx=(20,20), pady=(2, 20))
+        voice_cmd_entry.configure(justify="center")
+        column += 1
+        self.listvoice_cmd_var = ctk.StringVar(value=self.config.get(section="BOT", option="voices_command", fallback=''))
+        voices_cmd_entry = ctk.CTkEntry(self.parent,  width=100, height=30, border_width=1, fg_color="white", placeholder_text="say", text_color="black", textvariable=self.listvoice_cmd_var)
+        voices_cmd_entry.grid(row=row, column=column, padx=(20,20), pady=(2, 20))
+        voices_cmd_entry.configure(justify="center")
+
         ########################
 
         ####### Web Srv ########
@@ -135,12 +154,15 @@ class SettingsTab():
         column += 3
 
         # could undo some of these self's if in a method?
+        self.add_import_button = ctk.CTkButton(self.parent,height=30, text="Import All", command=self._import_e11_all)
+        self.add_import_button.grid(row=row, column=column, padx=10, pady=(2,10), sticky='n')
+
         self.add_v_button = ctk.CTkButton(self.parent,height=30, text="Add Voice", command=self.open_edit_popup)
-        self.add_v_button.grid(row=row, column=column, padx=10, pady=(2,10), sticky='n')
+        self.add_v_button.grid(row=row, column=column, padx=10, pady=(52,10), sticky='n')
         self.del_v_button = ctk.CTkButton(self.parent,height=30, text="Remove Voice", fg_color="#b1363d", hover_color="#772429", command=self._delete_voice)
-        self.del_v_button.grid(row=row, column=column, padx=10, pady=(42,10), sticky='n')
+        self.del_v_button.grid(row=row, column=column, padx=10, pady=(92,10), sticky='n')
         self.preview_v_button = ctk.CTkButton(self.parent,height=30, text="Preview Voice", command=self._preview_e11_voice)
-        self.preview_v_button.grid(row=row, column=column, padx=10, pady=(138,10), sticky='n')
+        self.preview_v_button.grid(row=row, column=column, padx=10, pady=(168,10), sticky='n')
 
         on_elevenlabs_connect.addListener(self._update_elevenlabs_connection)
         request_elevenlabs_connect.trigger()
@@ -160,6 +182,13 @@ class SettingsTab():
         else:
             self.del_v_button.configure(state="disabled")
             self.preview_v_button.configure(state="disabled")
+
+
+    def _import_e11_all(self):
+        client = ElevenLabsTTS(self.config)
+        success = client.import_all(True)
+        if success:
+            self._update_voice_list()
 
 
     def _preview_e11_voice(self):
@@ -208,6 +237,8 @@ class SettingsTab():
         self.config.set(section="BOT", option="prefix", value=str(self.prefix_var.get()))
         self.config.set(section="BOT", option="speak_command", value=self.speak_cmd_var.get().strip())
         self.config.set(section="BOT", option="join_command", value=self.join_cmd_var.get().strip())
+        self.config.set(section="BOT", option="voice_command", value=self.voice_cmd_var.get().strip())
+        self.config.set(section="BOT", option="voices_command", value=self.listvoice_cmd_var.get().strip())
         self.config.set(section="TWITCH", option="channel", value=self.channel_var.get())
         self.config.write_updates()
         ui_settings_twitch_channel_update_event.trigger([True, self.twitch_utils, 5])
@@ -218,9 +249,11 @@ class SettingsTab():
             self.e11labs_con_label.configure(text="ElevenLabs Connected", text_color="green")
             self._update_voice_list()
             self.add_v_button.configure(state="normal")
+            self.add_import_button.configure(state="normal")
         else:
             self.e11labs_con_label.configure(text="ElevenLabs Disconnected", text_color="red")
             self.add_v_button.configure(state="disabled")
+            self.add_import_button.configure(state="disabled")
             if self.e11_voices.size():
                 self.e11_voices.selection_clear()
                 while self.e11_voices.size():

--- a/src/ui/widgets/member_card.py
+++ b/src/ui/widgets/member_card.py
@@ -56,6 +56,7 @@ class MemberCard(ctk.CTkFrame):
             self.bg_label.bind("<Button-1>", self.open_edit_popup)
 
     def open_edit_popup(self, event=None):
+        self.member = run_coroutine_sync(fetch_member(name=self.member.name))
         MemberEditCard(self.member, self.config)
 
 class MemberEditCard(ctk.CTkToplevel):
@@ -76,7 +77,7 @@ class MemberEditCard(ctk.CTkToplevel):
         self.protocol("WM_DELETE_WINDOW", self.close_popup) 
 
         self.tts = {
-            SOURCE_LOCAL: LocalTTS(self.config),
+            SOURCE_LOCAL: LocalTTS(self.config, False),
             SOURCE_11L: ElevenLabsTTS(self.config)
         }
 


### PR DESCRIPTION
- Add get voices, set voice commands
  - Local:
    - Get voices returns shortened names for local tts. `!voices local`
    - Set voice by shortname to set to a local tts. `!voice Zira`
  - 11L:
    -  Get voices returns link to public library. `!voices 11L`  or `!voices elevenlabs`
    - Set voice by voice-id. It *must* be added to the user account to set properly, otherwise fails even on valid voice-id's. `!voice someWeirdANID`

- Query optimization for bulk deletions, can pass in voices by uid or a list of uid's
- Optimization on TTS engine instantiations
  - Only upsert local voices if not already present
  - 11L remove ones not available on the account from db
- Add import-all functionality for 11L
  - Import ALL voices available to account, and also remove ones no longer available
  - If a lot of voices, operation can take a second or few, done synchronously.
- Update member object in user-cards anytime they are clicked, ensuring up-to-date.

Closes #39 