### PR TITLE
decouple cache, config, tts instances

### DIFF
--- a/src/helpers/constants.py
+++ b/src/helpers/constants.py
@@ -1,11 +1,9 @@
 
 # Keep always as lowercase
-SOURCE_LOCAL = "local"
-SOURCE_11L = "elevenlabs"
-SOURCE_SE = 'streamelements'
+from enum import Enum
 
-SOURCES = [
-    SOURCE_LOCAL,
-    SOURCE_11L,
-    SOURCE_SE
-]
+
+class TTS_SOURCE(Enum): #pylint: disable=invalid-name
+    SOURCE_LOCAL = "local"
+    SOURCE_11L = "elevenlabs"
+    SOURCE_SE = 'streamelements'

--- a/src/helpers/instance_manager.py
+++ b/src/helpers/instance_manager.py
@@ -1,0 +1,97 @@
+import os
+import atexit
+from functools import lru_cache
+from logging import getLogger
+from diskcache import Cache
+
+from helpers.config import TCDNDConfig as Config
+
+# Eventually, this system will let us split up caches and configs
+# but for now, will allow us to share a single instance much better
+# and be able to get globally
+
+logger = getLogger("ChatDND")
+
+_cleanup_cbs = []
+
+def register_cleanup(obj, method='close'):
+    func = getattr(obj, method, None)
+    if func and callable(func):
+        _cleanup_cbs.append(func)
+
+@atexit.register
+def _cleanup():
+    for func in _cleanup_cbs:
+        try:
+            func()
+        except Exception as e:
+            logger.warning(f"Could not close instance at exit: {func} - {e}")
+
+#### Cache #####
+
+_cache_registry = {}
+_cache_store = {}
+
+@lru_cache(maxsize=None)
+def get_cache(name='default') -> Cache:
+    cache = None
+    if name in _cache_store:
+        cache = _cache_store.get(name)
+        return cache
+    path = _cache_registry.get(name)
+    if path:
+        cache = Cache(directory=path)
+    else:
+        cache = Cache()
+    _cache_store[name] = cache
+    register_cleanup(cache)
+    return cache
+
+
+def init_cache(name='default', path=None) -> Cache:
+    if name in _cache_registry:
+        return get_cache(name)
+    if path is None or not os.path.isdir(path):
+        logger.error(f"Attempted to initialize cache [{name}] without invalid path: {path}.")
+        return get_cache(name)
+
+    _cache_registry[name] = path
+    return get_cache(name)
+
+################
+
+#### Config ####
+
+_config_registry = {}
+_config_store = {}
+
+@lru_cache(maxsize=None)
+def get_config(name='default') -> Config:
+    if name in _config_store:
+        return _config_store.get(name)
+    config = Config()
+    path = _config_registry.get(name)
+    if path:
+        config.setup(path)
+    _config_store[name] = config
+    return config
+
+def init_config(name='default', path=None) -> Config:
+    if name in _config_registry:
+        return get_config(name)
+    if path is None or not os.path.isfile(path):
+        logger.error(f"Attempted to initialize config [{name}] without invalid path: {path}.")
+        return get_config(name)
+
+    _config_registry[name] = path
+    config = get_config(name)
+    config.setup(path)
+    _config_store[name] = config
+    return config
+
+def reload_cache(name='default'):
+    if name in _config_registry:
+        config = get_config(name)
+        config.setup(_config_registry.get(name))
+
+###############

--- a/src/helpers/instance_manager.py
+++ b/src/helpers/instance_manager.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import atexit
 from functools import lru_cache
 from logging import getLogger
@@ -51,10 +52,10 @@ def get_cache(name='default') -> Cache:
 def init_cache(name='default', path=None) -> Cache:
     if name in _cache_registry:
         return get_cache(name)
-    if path is None or not os.path.isdir(path):
+    if path is None:
         logger.error(f"Attempted to initialize cache [{name}] without invalid path: {path}.")
         return get_cache(name)
-
+    Path(path).mkdir(parents=True, exist_ok=True)
     _cache_registry[name] = path
     return get_cache(name)
 

--- a/src/helpers/utils.py
+++ b/src/helpers/utils.py
@@ -5,8 +5,10 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Coroutine, TypeVar
 import requests
+from diskcache import Cache
 from packaging.version import Version
 from _version import __version__ as current_version
+from helpers.instance_manager import get_cache, get_config
 
 T = TypeVar("T")
 
@@ -77,4 +79,11 @@ def check_for_updates():
     else:
         if Version(current_version.replace("v", "")) < Version(latest.replace("v", "")):
             return f"https://github.com/{owner}/{repo}/releases/tag/{latest}"
+    return None
+
+
+def try_get_cache(name="default") -> Cache | None:
+    config = get_config(name)
+    if config.getboolean(section="CACHE", option="enabled"):
+       return get_cache(name)
     return None

--- a/src/initialize.py
+++ b/src/initialize.py
@@ -4,15 +4,16 @@ import subprocess
 import argparse
 import static_ffmpeg
 
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Run the application.")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging level.")
     return parser.parse_args()
 
-args = parse_args()
-os.environ["TCDND_DEBUG_MODE"] = "1" if args.debug else "0"
+_args = parse_args()
+os.environ["TCDND_DEBUG_MODE"] = "1" if _args.debug else "0"
 
-from custom_logger.logger import logger
+from custom_logger.logger import logger # pylint: disable=wrong-import-position
 
 logger.info("Setting up ffmpeg...")
 static_ffmpeg.add_paths()

--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,9 @@ cache_dir = os.path.join(cwd, ".tcdnd-cache/")
 
 # Initialize config and cache
 config = init_config(name='default', path=config_path)
+
+if config.has_option(section="CACHE", option="directory"):
+    cache_dir = config.get(section='CACHE', option='directory')
 cache = init_cache(name='default', path=cache_dir)
 
 if not config.has_option(section="CACHE", option="directory"):

--- a/src/tts/__init__.py
+++ b/src/tts/__init__.py
@@ -1,17 +1,34 @@
+from logging import getLogger
+from functools import lru_cache
+
 from tts.local_tts import LocalTTS
 from tts.elevenlabs_tts import ElevenLabsTTS
 from tts.streamelements_tts import StreamElementsTTS
 from tts.tts import TTS
-from helpers.constants import SOURCES
-from helpers import TCDNDConfig as Config
+from helpers.constants import TTS_SOURCE
 
-__all__ = ["SOURCES", "LocalTTS", "ElevenLabsTTS", "StreamElementsTTS", "initialize_tts", "tts_instances", 'TTS']
+logger = getLogger("ChatDND")
 
-tts_instances = {}
+__all__ = ["LocalTTS", "ElevenLabsTTS", "StreamElementsTTS", 'TTS', "get_tts"]
 
+_tts_store_ = {}
+_tts_classes_ = [LocalTTS, ElevenLabsTTS, StreamElementsTTS]
 
-def initialize_tts(config: Config):
-    # Initialize once globally and import instances where needed
-    for tts_cls in [LocalTTS, ElevenLabsTTS, StreamElementsTTS]:
-        if tts_cls.source_type in SOURCES and tts_cls.source_type not in tts_instances:
-            tts_instances[tts_cls.source_type] = tts_cls(config, True)
+# def initialize_tts():
+#     # Initialize once globally and import instances where needed
+#     for tts_cls in [LocalTTS, ElevenLabsTTS, StreamElementsTTS]:
+#         if tts_cls.source_type in SOURCES and tts_cls.source_type not in tts_instances:
+#             tts_instances[tts_cls.source_type] = tts_cls()
+
+@lru_cache(maxsize=None)
+def get_tts(name: TTS_SOURCE) -> LocalTTS | ElevenLabsTTS | StreamElementsTTS:
+    if not name:
+        return None
+    if name in _tts_store_:
+        return  _tts_store_.get(name)
+    for cls in _tts_classes_:
+        if cls.source_type == name:
+            tts = cls()
+            _tts_store_[name] = tts
+            return tts
+    return None

--- a/src/tts/elevenlabs_tts.py
+++ b/src/tts/elevenlabs_tts.py
@@ -57,7 +57,8 @@ class ElevenLabsTTS(TTS):
             try:
                 test_client = ElevenLabs(api_key=key)
                 # This will cause an exception if invalid api key
-                user_subscription = test_client.user.get_subscription()
+                test_client.user.subscription
+                user_subscription = test_client.user.subscription.get()
                 count = user_subscription.character_count
                 limit = user_subscription.character_limit
                 on_elevenlabs_subscription_update.trigger([count, limit])
@@ -115,7 +116,7 @@ class ElevenLabsTTS(TTS):
             yield (header + chunk, duration)
             chunk = output.read(chunk_size)
 
-        user_subscription = await self.client.user.get_subscription()
+        user_subscription = await self.client.user.subscription.get()
         count = user_subscription.character_count
         limit = user_subscription.character_limit
         on_elevenlabs_subscription_update.trigger([count, limit])
@@ -256,7 +257,7 @@ class ElevenLabsTTS(TTS):
                 audio = iter(audio)
 
                 try:
-                    user_subscription = client.user.get_subscription()
+                    user_subscription = client.user.subscription.get()
                     count = user_subscription.character_count
                     limit = user_subscription.character_limit
                     on_elevenlabs_subscription_update.trigger([count, limit])

--- a/src/tts/elevenlabs_tts.py
+++ b/src/tts/elevenlabs_tts.py
@@ -57,7 +57,6 @@ class ElevenLabsTTS(TTS):
             try:
                 test_client = ElevenLabs(api_key=key)
                 # This will cause an exception if invalid api key
-                test_client.user.subscription
                 user_subscription = test_client.user.subscription.get()
                 count = user_subscription.character_count
                 limit = user_subscription.character_limit

--- a/src/tts/elevenlabs_tts.py
+++ b/src/tts/elevenlabs_tts.py
@@ -6,14 +6,13 @@ from elevenlabs.client import AsyncElevenLabs
 from elevenlabs.client import ElevenLabs
 from elevenlabs.types import Voice as ELVoice
 from elevenlabs import play
-
-from diskcache import Cache
+from elevenlabs.core.api_error import ApiError as ELApiError
 
 from tts.tts import TTS, create_wav_header
 
-from helpers import TCDNDConfig as Config
-from helpers.utils import run_coroutine_sync
-from helpers.constants import SOURCE_11L
+from helpers.instance_manager import get_config
+from helpers.utils import run_coroutine_sync, try_get_cache
+from helpers.constants import TTS_SOURCE
 from custom_logger.logger import logger
 
 from chatdnd.events.tts_events import (
@@ -31,29 +30,16 @@ MODEL = "eleven_flash_v2_5"  #'eleven_monolingual_v1'
 
 
 class ElevenLabsTTS(TTS):
-    source_type = SOURCE_11L
-    def __init__(self, config: Config, full_instance: bool = False):
-        super().__init__(config=None)
-        self.full_instance = full_instance
-        self.config = config
+    source_type = TTS_SOURCE.SOURCE_11L
+    def __init__(self):
+        super().__init__()
         self.client: AsyncElevenLabs = None
+        request_elevenlabs_connect.addListener(self.setup)
 
-        if self.full_instance:
-            request_elevenlabs_connect.addListener(self.setup)
-            self.setup()
-            on_elevenlabs_test_speak.addListener(self.test_speak)
+        self.setup()
+        on_elevenlabs_test_speak.addListener(self.test_speak)
 
         self.sample_rate = int(FORMAT.rsplit("_", maxsplit=1)[-1])
-
-        if config.getboolean(section="CACHE", option="enabled"):
-            # Caching in general, but for here, it's specific to API results
-            cache_dir = config.get(section="CACHE", option="directory", fallback=None)
-            if not cache_dir:
-                self.cache = Cache()
-            else:
-                self.cache = Cache(directory=cache_dir)
-        else:
-            self.cache = None
 
     @property
     def voices(self) -> dict:
@@ -65,9 +51,9 @@ class ElevenLabsTTS(TTS):
         return d
 
     def setup(self):
-        if self.full_instance:
-            on_elevenlabs_connect.trigger([False])
-        if key := self.config.get(section="ELEVENLABS", option="api_key"):
+        on_elevenlabs_connect.trigger([False])
+        config = get_config("default")
+        if key := config.get(section="ELEVENLABS", option="api_key"):
             try:
                 test_client = ElevenLabs(api_key=key)
                 # This will cause an exception if invalid api key
@@ -77,24 +63,23 @@ class ElevenLabsTTS(TTS):
                 on_elevenlabs_subscription_update.trigger([count, limit])
 
                 self.client = AsyncElevenLabs(api_key=key)
-                if self.full_instance:
-                    # Remove all voices from system if they are not available on the account anymore
-                    available_voices = [v.voice_id for v in test_client.voices.get_all().voices]
-                    db_voice_ids = run_coroutine_sync(get_all_voice_ids(source=self.source_type))
-                    unavailable_voices = []
-                    for uid in db_voice_ids:
-                        if uid not in available_voices:
-                            unavailable_voices.append(uid)
 
-                    if unavailable_voices:
-                        run_coroutine_sync(remove_tts(voice_id=unavailable_voices))
-                        run_coroutine_sync(delete_voice(uid=unavailable_voices, source=self.source_type))
-                    on_elevenlabs_connect.trigger([True])
+                # Remove all voices from system if they are not available on the account anymore
+                available_voices = [v.voice_id for v in test_client.voices.get_all().voices]
+                db_voice_ids = run_coroutine_sync(get_all_voice_ids(source=self.source_type))
+                unavailable_voices = []
+                for uid in db_voice_ids:
+                    if uid not in available_voices:
+                        unavailable_voices.append(uid)
+
+                if unavailable_voices:
+                    run_coroutine_sync(remove_tts(voice_id=unavailable_voices))
+                    run_coroutine_sync(delete_voice(uid=unavailable_voices, source=self.source_type))
+                on_elevenlabs_connect.trigger([True])
 
             except Exception as e:
                 logger.warning(f"ElevenLabs Exception: {e}")
-                if self.full_instance:
-                    on_elevenlabs_connect.trigger([False])
+                on_elevenlabs_connect.trigger([False])
 
     async def audio_stream_generator(self, text="Hello World!", voice_id: str = None):
         if not voice_id or not self.client:
@@ -137,7 +122,8 @@ class ElevenLabsTTS(TTS):
 
     def import_all(self, run_sync_always: bool = False) -> bool:
         did_import = False
-        if key := self.config.get(section="ELEVENLABS", option="api_key"):
+        config = get_config(name="default")
+        if key := config.get(section="ELEVENLABS", option="api_key"):
             client = ElevenLabs(api_key=key)
 
             try:
@@ -168,18 +154,22 @@ class ElevenLabsTTS(TTS):
 
     def get_voice_object(self, voice_id: str = "", run_sync_always: bool = False) -> ELVoice | None:
         # Voice by id, will attempt to find it and cache it
-        if not voice_id or not self.config.get(section="ELEVENLABS", option="api_key", fallback=None):
+
+        config = get_config(name="default")
+        if not voice_id or not config.get(section="ELEVENLABS", option="api_key", fallback=None):
             return None
 
         key = f"11l.voice.{voice_id}"
         v: ELVoice = None
-        if self.cache is not None:
-            v = self.cache.get(key=key, default=None)
+
+        cache = try_get_cache("default")
+        if cache:
+            v = cache.get(key=key, default=None)
             if v:
                 logger.debug(f"Fetched cached preview audio for `{voice_id}`")
 
         if not v:
-            client = ElevenLabs(api_key=self.config.get(section="ELEVENLABS", option="api_key"))
+            client = ElevenLabs(api_key=config.get(section="ELEVENLABS", option="api_key"))
             v = None
             try:
                 x = client.voices.get_all().voices
@@ -190,10 +180,10 @@ class ElevenLabsTTS(TTS):
                 v = client.voices.get(voice_id)
             except Exception as e:
                 logger.error(e)
-            if v:
-                self.cache.set(
+            if v and cache:
+                cache.set(
                     key=key,
-                    expire=self.config.getint(
+                    expire=config.getint(
                         section="CACHE",
                         option="tts_cache_expiry",
                         fallback=7 * 24 * 60 * 60 * 4 * 3,
@@ -230,7 +220,8 @@ class ElevenLabsTTS(TTS):
         return ElevenLabsTTS.voices_messages()
 
     def test_speak(self, text: str = "Hello there. How are you?", voice_id: str = None):
-        if not voice_id or not self.config.get(section="ELEVENLABS", option="api_key", fallback=None):
+        config = get_config(name="default")
+        if not voice_id or not config.get(section="ELEVENLABS", option="api_key", fallback=None):
             return
         # Could use `preview_url` from Voice object, but it is different for each voice,
         # likely best to spend a few credits for consistency and cache it for a long time
@@ -238,25 +229,24 @@ class ElevenLabsTTS(TTS):
 
         key = f"11l.preview.{voice_id}"
         audio = None
-
-        if self.cache is not None:
-            audio_l = self.cache.get(key=key, default=None)
+        if cache := try_get_cache("default"):
+            audio_l = cache.get(key=key, default=None)
             if audio_l:
                 audio = iter(audio_l)
                 logger.debug(f"Fetched cached preview audio for `{voice_id}`")
         if not audio:
             def preview_audio_th():
                 try:
-                    client = ElevenLabs(api_key=self.config.get(section="ELEVENLABS", option="api_key"))
+                    client = ElevenLabs(api_key=config.get(section="ELEVENLABS", option="api_key"))
                     client.user.get()  # Trigger bad api key
                 except Exception:
                     on_elevenlabs_connect.trigger([False])  # needed?
                     return
                 audio = list(client.text_to_speech.convert(text=text, voice_id=voice_id, model_id=MODEL))
-                if self.cache:
-                    self.cache.set(
+                if cache := try_get_cache("default"):
+                    cache.set(
                         key=key,
-                        expire=self.config.getint(
+                        expire=config.getint(
                             section="CACHE",
                             option="tts_cache_expiry",
                             fallback=7 * 24 * 60 * 60 * 4 * 3,
@@ -265,10 +255,14 @@ class ElevenLabsTTS(TTS):
                     )
                 audio = iter(audio)
 
-                user_subscription = client.user.get_subscription()
-                count = user_subscription.character_count
-                limit = user_subscription.character_limit
-                on_elevenlabs_subscription_update.trigger([count, limit])
+                try:
+                    user_subscription = client.user.get_subscription()
+                    count = user_subscription.character_count
+                    limit = user_subscription.character_limit
+                    on_elevenlabs_subscription_update.trigger([count, limit])
+                except ELApiError as ex:
+                    logger.warning(f"Elevenlabs API Error, cannot update credit count: {ex}")
+
                 play(audio)
             # Perform the whole request in a separate thread to avoid microsecond hang
             thread = threading.Thread(target=preview_audio_th)

--- a/src/tts/tts.py
+++ b/src/tts/tts.py
@@ -1,5 +1,8 @@
+from logging import getLogger
 import struct
-from helpers import TCDNDConfig as Config
+from helpers.constants import TTS_SOURCE
+
+logger = getLogger("ChatDND")
 
 
 def create_wav_header(sample_rate, bits_per_sample, num_channels, data_size):
@@ -27,15 +30,15 @@ def create_wav_header(sample_rate, bits_per_sample, num_channels, data_size):
 
 
 class TTS:
-    source_type: str = ""
+    source_type: TTS_SOURCE
     voices: dict = dict()
     sample_rate = 22050
     bits_per_sample = 16
     num_channels = 1
     max_chunk_size = 1024 * 8 * 8 * 2 * 2  # 256kb
 
-    def __init__(self, config: Config):
-        self.config = config
+    def __init__(self):
+        logger.debug(f"TTS Instance created of type: {self.source_type}")
 
     def get_voices(self) -> dict:
         return self.voices

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -4,7 +4,6 @@ from _version import __version__ as app_version
 from chatdnd import SessionManager
 from chatdnd.events.ui_events import ui_request_floating_notif
 from custom_logger.logger import logger
-from helpers import TCDNDConfig as Config
 from helpers.utils import get_resource_path
 from twitch.chat import ChatController
 from twitch.utils import TwitchUtils
@@ -25,7 +24,6 @@ class DesktopApp(ctk.CTk):
         self,
         session_mgr: SessionManager,
         chat_ctrl: ChatController,
-        config: Config,
         twitch_utils: TwitchUtils,
     ):
         super().__init__()
@@ -33,7 +31,6 @@ class DesktopApp(ctk.CTk):
         self.protocol("WM_DELETE_WINDOW", self.on_close)
 
         self.resizable(False, False)
-        self.config: Config = config
         self.twitch_utils = twitch_utils
         self.session_mgr = session_mgr
         self.chat_ctrl = chat_ctrl
@@ -67,7 +64,7 @@ class DesktopApp(ctk.CTk):
         # TODO - see if we even need to pass in chat_ctrl, or if we can purely use my Events and triggers
         home = HomeTab(home_tab, self.chat_ctrl, self.context_menu)
         users = UsersTab(users_tab, self.chat_ctrl, self.context_menu)
-        settings = SettingsTab(settings_tab, self.config, self.twitch_utils)
+        settings = SettingsTab(settings_tab, self.twitch_utils)
         assert all([home, users, settings])
 
     def button_callback(self):

--- a/src/ui/tabs/home.py
+++ b/src/ui/tabs/home.py
@@ -1,6 +1,7 @@
 import customtkinter as ctk
 from custom_logger.logger import logger
 
+from helpers.instance_manager import get_config
 from ui.widgets.CTkPopupMenu.custom_popupmenu import CTkContextMenu, ContextMenuTypes
 from ui.widgets.member_card import MemberCard
 from twitch.chat import ChatController
@@ -17,9 +18,10 @@ from chatdnd.events.ui_events import ui_force_home_party_update
 class HomeTab:
     def __init__(self, parent, chat_ctrl: ChatController, context_menu: CTkContextMenu):
         self.parent = parent
-        self.config = chat_ctrl.config
         self.chat_ctrl = chat_ctrl
         self.context_menu = context_menu
+
+        config = get_config('default')
 
         self.parent.grid_columnconfigure(1, weight=0)
         self.parent.grid_columnconfigure((0, 2), weight=1)
@@ -41,7 +43,7 @@ class HomeTab:
         session_status_label = ctk.CTkLabel(_inner_frame, textvariable=self.session_status_var, height=20, width=150)
         session_status_label.grid(row=0, column=1, sticky="w", padx=(10, 0))
 
-        self.party_size_var = ctk.IntVar(value=self.config.getint(section="DND", option="party_size", fallback=4))
+        self.party_size_var = ctk.IntVar(value=config.getint(section="DND", option="party_size", fallback=4))
         self.party_label_var = ctk.StringVar(value=f"Party Size - {self.party_size_var.get()}")
         party_label = ctk.CTkLabel(_inner_frame, textvariable=self.party_label_var)
         party_label.grid(row=1, column=0, pady=(16, 4), columnspan=2)
@@ -152,7 +154,6 @@ class HomeTab:
                 member,
                 self.context_menu,
                 self.chat_ctrl,
-                self.config,
                 width=130,
                 height=170,
                 textsize=10,
@@ -246,7 +247,8 @@ class HomeTab:
         self.queue_label_var.set(value=f"{len(self.chat_ctrl.session_mgr.session.queue)} in Queue")
 
     def _update_party_limit(self, value):
-        if int(value) != self.config.getint(section="DND", option="party_size", fallback=-1):
+        config = get_config('default')
+        if int(value) != config.getint(section="DND", option="party_size", fallback=-1):
             self.party_label_var.set(f"Party Size - {int(value)}")
-            self.config.set(section="DND", option="party_size", value=str(int(value)))
-            self.config.write_updates()
+            config.set(section="DND", option="party_size", value=str(int(value)))
+            config.write_updates()

--- a/src/ui/tabs/users.py
+++ b/src/ui/tabs/users.py
@@ -88,7 +88,7 @@ class UsersTab:
                 members = await fetch_paginated_members(self.page, self.per_page, name_filter=self.name_filter)
 
                 new_cards = [
-                    MemberCard(self.members_list_frame, member, self.context_menu, self.chat_ctrl, self.chat_ctrl.config) for member in members
+                    MemberCard(self.members_list_frame, member, self.context_menu, self.chat_ctrl) for member in members
                 ]
 
                 columns = 6


### PR DESCRIPTION
Decouples TTS instances and enumerates sources

Decouples config and cache.

This will allow us to eventually support multiple, but for now, allows us to fetch a shared instance from anywhere with just a function call, or create if not found. Akin to logging.getLogger.

Uses LRU Cache when possible, but if not due to loop/thread shenanigans, will find it in shared registry store - technically makes LRU cache redundant but eh, it's nice when it works most of the time.